### PR TITLE
fix(swap): Properly restore cursor and window view when swapping bufs

### DIFF
--- a/lua/smart-splits/swap.lua
+++ b/lua/smart-splits/swap.lua
@@ -37,26 +37,30 @@ function M.swap_bufs(direction, opts)
   local win_2 = vim.api.nvim_get_current_win()
   local view_2 = vim.fn.winsaveview()
 
-  if buf_1 == buf_2 then
-    -- same buffer in both windows, so there is nothing to swap but the cursor and
-    -- scroll position; folds have to come off first or restoring the view moves
-    -- the cursor somewhere else
-    local folds_1 = vim.api.nvim_get_option_value('foldenable', { win = win_1 })
-    local folds_2 = vim.api.nvim_get_option_value('foldenable', { win = win_2 })
-    vim.api.nvim_set_option_value('foldenable', false, { win = win_1 })
-    vim.api.nvim_set_option_value('foldenable', false, { win = win_2 })
-
-    vim.api.nvim_set_current_win(win_1)
-    vim.fn.winrestview(view_2)
-    vim.api.nvim_set_current_win(win_2)
-    vim.fn.winrestview(view_1)
-
-    vim.api.nvim_set_option_value('foldenable', folds_1, { win = win_1 })
-    vim.api.nvim_set_option_value('foldenable', folds_2, { win = win_2 })
-  else
+  -- NB: if the buffers are the same,
+  -- we don't need to swap them, but we
+  -- do still want to swap the view/cursor/etc.
+  -- below; do not early return inside this
+  -- if statement
+  if buf_1 ~= buf_2 then
     vim.api.nvim_win_set_buf(win_2, buf_1)
     vim.api.nvim_win_set_buf(win_1, buf_2)
   end
+
+  -- restore scroll positions; folds have to come off first or restoring
+  -- the view moves the cursor somewhere else
+  local folds_1 = vim.api.nvim_get_option_value('foldenable', { win = win_1 })
+  local folds_2 = vim.api.nvim_get_option_value('foldenable', { win = win_2 })
+  vim.api.nvim_set_option_value('foldenable', false, { win = win_1 })
+  vim.api.nvim_set_option_value('foldenable', false, { win = win_2 })
+
+  vim.api.nvim_set_current_win(win_1)
+  vim.fn.winrestview(view_2)
+  vim.api.nvim_set_current_win(win_2)
+  vim.fn.winrestview(view_1)
+
+  vim.api.nvim_set_option_value('foldenable', folds_1, { win = win_1 })
+  vim.api.nvim_set_option_value('foldenable', folds_2, { win = win_2 })
 
   local move_cursor = opts.move_cursor
   if move_cursor == nil then

--- a/tests/test_swap_spec.lua
+++ b/tests/test_swap_spec.lua
@@ -60,6 +60,88 @@ describe('swap_buf', function()
       ss.swap_buf_right({ move_cursor = false })
       assert.equals(wins[1], helpers.curwin())
     end)
+
+    it('preserves scroll position when move_cursor is true', function()
+      ss.setup({ swap = { move_cursor = true } })
+      local wins = helpers.create_vsplits(2)
+      helpers.unique_buffers(wins)
+
+      -- Fill buffers with enough lines to scroll
+      local lines = {}
+      for i = 1, 100 do
+        table.insert(lines, 'Line ' .. i)
+      end
+      vim.api.nvim_buf_set_lines(vim.api.nvim_win_get_buf(wins[1]), 0, -1, false, lines)
+      vim.api.nvim_buf_set_lines(vim.api.nvim_win_get_buf(wins[2]), 0, -1, false, lines)
+
+      -- Scroll each window to different positions
+      helpers.focus(wins[1])
+      vim.api.nvim_win_set_cursor(wins[1], { 50, 0 })
+      vim.cmd('normal! zz')
+      local view_1_before = vim.fn.winsaveview()
+
+      helpers.focus(wins[2])
+      vim.api.nvim_win_set_cursor(wins[2], { 75, 0 })
+      vim.cmd('normal! zz')
+      local view_2_before = vim.fn.winsaveview()
+
+      -- Swap with move_cursor
+      helpers.focus(wins[1])
+      ss.swap_buf_right()
+
+      -- Cursor should be in win_2 (following buf_1)
+      assert.equals(wins[2], helpers.curwin())
+
+      -- Scroll position should be preserved
+      local view_1_after = vim.fn.winsaveview()
+      assert.equals(view_1_before.topline, view_1_after.topline)
+      assert.equals(view_1_before.lnum, view_1_after.lnum)
+
+      -- Check win_1 as well
+      helpers.focus(wins[1])
+      local view_2_after = vim.fn.winsaveview()
+      assert.equals(view_2_before.topline, view_2_after.topline)
+      assert.equals(view_2_before.lnum, view_2_after.lnum)
+    end)
+
+    it('preserves scroll position when move_cursor is false', function()
+      -- default: move_cursor = false
+      local wins = helpers.create_vsplits(2)
+      helpers.unique_buffers(wins)
+
+      local lines = {}
+      for i = 1, 100 do
+        table.insert(lines, 'Line ' .. i)
+      end
+      vim.api.nvim_buf_set_lines(vim.api.nvim_win_get_buf(wins[1]), 0, -1, false, lines)
+      vim.api.nvim_buf_set_lines(vim.api.nvim_win_get_buf(wins[2]), 0, -1, false, lines)
+
+      helpers.focus(wins[1])
+      vim.api.nvim_win_set_cursor(wins[1], { 50, 0 })
+      vim.cmd('normal! zz')
+      local view_1_before = vim.fn.winsaveview()
+
+      helpers.focus(wins[2])
+      vim.api.nvim_win_set_cursor(wins[2], { 75, 0 })
+      vim.cmd('normal! zz')
+      local view_2_before = vim.fn.winsaveview()
+
+      -- Swap without move_cursor (default)
+      helpers.focus(wins[1])
+      ss.swap_buf_right()
+
+      -- Cursor should stay in win_1
+      assert.equals(wins[1], helpers.curwin())
+
+      -- win_1 now has buf_2, so it should have view_2's scroll position
+      local view_1_after = vim.fn.winsaveview()
+      assert.equals(view_2_before.topline, view_1_after.topline)
+
+      -- win_2 now has buf_1, so it should have view_1's scroll position
+      helpers.focus(wins[2])
+      local view_2_after = vim.fn.winsaveview()
+      assert.equals(view_1_before.topline, view_2_after.topline)
+    end)
   end)
 
   describe('vertical swaps', function()


### PR DESCRIPTION
- fix(swap): Properly restore cursor and window view when swapping bufs

Noticed this not behaving quite right.

@geodimm would you mind testing this with
`config.swap.move_cursor = true` and `config.swap.move_cursor = false`?

It should swap the buffers between nvim windows, and the buffers should
remain scrolled to the same file position and cursor should remain on
the correct line.

When `config.swap.move_cursor = true`, your cursor should follow the
swapped buf.